### PR TITLE
feat: add GLM model icon

### DIFF
--- a/vendors/icons/glm.svg
+++ b/vendors/icons/glm.svg
@@ -1,0 +1,1 @@
+<svg fill="currentColor" fill-rule="evenodd" height="1em" style="flex:none;line-height:1" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg"><title>GLM</title><path d="M5 4h14a1 1 0 011 1v2.2a1 1 0 01-.28.69L11.2 16.6H19a1 1 0 011 1V19a1 1 0 01-1 1H5a1 1 0 01-1-1v-2.2a1 1 0 01.28-.69L12.8 7.4H5a1 1 0 01-1-1V5a1 1 0 011-1z"></path></svg>


### PR DESCRIPTION
## Summary

Adds a GLM (Z.ai) icon at `vendors/icons/glm.svg`, used by the GLM 5.2 model in the Relevance model selector / Inventor picker.

The icon is a monochrome "Z" lettermark (Z.ai branding) using `currentColor` and a `0 0 24 24` viewBox, consistent with the other LLM provider icons in this directory (e.g. `xai.svg`, `groq.svg`).

The nodeapi/builder-app side resolves this file from the model's `group_label` ("GLM") → `getIconFromVendor("glm")` → `vendors/icons/glm.svg`.

## Companion PR

Must merge alongside the backend + frontend changes that reference this icon:
- RelevanceAI/relevance-api-node#15757

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RUYAYedi6DcqAP3BAPdFPR)_